### PR TITLE
Z_ksi fully fixed, f_x slightly changed, full working version for all…

### DIFF
--- a/laba2.py
+++ b/laba2.py
@@ -46,13 +46,15 @@ for i in range(n - 1):
         for i_2 in range(i_1 + 2):
             current_x_k = x_k[len(x_k) - 1][i_2]
             current_ksi_k = ksi_k[i_1][i_2]
-            if current_x_k > max(f) or current_ksi_k > max(f):
+            if i == 0 and current_ksi_k > max(f):
                 tab_3[i][(i_1 + 1) * step].update({current_x_k: 0})
                 continue
             if i_2 == 0:
                 f_x = 0
-            else:
+            elif current_x_k in f.keys():
                 f_x = f[current_x_k][f_len - i - 2]
+            else:
+                f_x = 0
             if i_2 == i_1 + 1:
                 Z_ksi = 0
             else:
@@ -60,15 +62,18 @@ for i in range(n - 1):
                     if i_2 == 0:
                         key = max(tab_3[i - 1][(i_1 + 1) * step], 
                                   key=tab_3[i - 1][(i_1 + 1) * step].get)
-                        Z_ksi = tab_3[i-1][(i_1 + 1) * step][key]
+                        Z_ksi = tab_3[i - 1][(i_1 + 1) * step][key]
                     else:
                         if i_2 == 1:
                             Z_ksi = tab_3[i][(i_1) * step][(i_2 - 1) * step]
                         else:
                             Z_ksi = tab_3[i][(i_1) * step][(i_2 - 1) * step] - \
-                            f[x_k[len(x_k) - 1][i_2 - 1]][f_len-i-2]
+                            f[x_k[len(x_k) - 1][i_2 - 1]][f_len - i - 2]
                 else:
-                    Z_ksi = f[current_ksi_k][-a - 1]
+                    if current_ksi_k > max(f):
+                        Z_ksi = tab_3[i][(i_1) * step][(i_2) * step]
+                    else:
+                        Z_ksi = f[current_ksi_k][-a - 1]
             tab_3[i][(i_1 + 1) * step].update({current_x_k: f_x + Z_ksi})
         a += 1
 


### PR DESCRIPTION
… exercises.

1. `Z_ksi` looks more for already computed values when budget(or `n`) over than max key of `f` list.
2. Add check for `f_x` - In an exceptional situation, when there is shortage  of key from `f` list, always becomes zero.

- [x] main part
- [x] ex.6a
- [x] ex.6b
- [x] ex.6c
- [x] ex.7